### PR TITLE
fix: tx 암묵적 any 타입 오류 수정

### DIFF
--- a/src/services/code-analysis-service/code-analysis.service.ts
+++ b/src/services/code-analysis-service/code-analysis.service.ts
@@ -2,6 +2,7 @@ import prisma from '@/lib/prisma';
 import { updateVersionStatusSafely } from '@/services/version-service/version-status-updater.service';
 import type { SarifCodeIssue, RawSarif } from '@/types/sarif';
 import { extractSemgrepIssuesWithRule } from '@/utils/parseSarifSemgrep';
+import type { Prisma } from '@prisma/client';
 
 export async function handleSemgrepResult(
   versionId: number,
@@ -35,7 +36,8 @@ export async function handleSemgrepResult(
   try {
     const sarif = sarifRaw as RawSarif;
     const issues: SarifCodeIssue[] = extractSemgrepIssuesWithRule(sarif);
-    await prisma.$transaction(async (tx) => {
+
+    await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       const analysis = await tx.codeAnalysis.upsert({
         where: { versionId },
         update: {


### PR DESCRIPTION
# PR

## PR 요약
- Docker 빌드 중 tx 파라미터에 암묵적 any 타입 에러 발생해 Prisma.TransactionClient 타입 명시했습니다.
- 로컬 dev 환경에서는 통과되던 부분이라 타입 검사 범위 차이로 인한 문제인 것 같습니다.

## 변경된 점
- code-analysis.service.ts에서 tx 파라미터에 Prisma.TransactionClient 타입을 명시

## 이슈 번호
resolved #48 