### PR TITLE
feat:Project 데이터 접근 서비스 구현

### DIFF
--- a/src/services/db-access-service/project.db.service.ts
+++ b/src/services/db-access-service/project.db.service.ts
@@ -11,7 +11,6 @@ import { Project, Prisma } from '@prisma/client'; // Prisma에서 생성된 타�
 export const createProjectInDB = async (
   projectData: Prisma.ProjectCreateInput
 ): Promise<Project> => {
-  // try...catch 블록 없이, 에러는 호출한 곳으로 전파됩니다.
   const newProject = await prisma.project.create({
     data: projectData,
   });
@@ -56,17 +55,53 @@ export const findProjectByDomainFromDB = async (
 
 /**
  * 특정 사용자가 소유한 모든 프로젝트 목록을 조회합니다.
+ * (예: "내 프로젝트" 목록 기능에 사용)
  * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
  * @param ownerId 소유자의 ID
+ * @param options (선택적) 정렬, 페이지네이션, 관계 포함 등의 옵션
  * @returns Project 객체의 배열
  * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
  */
 export const findProjectsByOwnerIdFromDB = async (
-  ownerId: number
+  ownerId: number,
+  options?: {
+    orderBy?: Prisma.ProjectOrderByWithRelationInput | Prisma.ProjectOrderByWithRelationInput[];
+    skip?: number;
+    take?: number;
+    include?: Prisma.ProjectInclude;
+  }
 ): Promise<Project[]> => {
   const projects = await prisma.project.findMany({
     where: { ownerId: ownerId },
-    orderBy: { createdAt: 'desc' }, // 예시: 최신 생성일 순으로 정렬
+    orderBy: options?.orderBy || { createdAt: 'desc' },
+    skip: options?.skip,
+    take: options?.take,
+    include: options?.include,
+  });
+  return projects;
+};
+
+/**
+ * 시스템에 있는 모든 프로젝트 목록을 조회합니다.
+ * 로그인한 사용자가 (권한 구분 없이) 모든 프로젝트를 볼 수 있는 시나리오에 사용됩니다.
+ * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
+ * @param options (선택적) 정렬, 페이지네이션, 관계 포함 등의 옵션 (예: 소유자 정보 포함)
+ * @returns Project 객체의 배열
+ * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
+ */
+export const findAllProjectsDB = async (
+  options?: {
+    orderBy?: Prisma.ProjectOrderByWithRelationInput | Prisma.ProjectOrderByWithRelationInput[];
+    skip?: number;
+    take?: number;
+    include?: Prisma.ProjectInclude; // 예: { owner: { select: { id: true, name: true, email: true } } }
+  }
+): Promise<Project[]> => {
+  const projects = await prisma.project.findMany({
+    orderBy: options?.orderBy || { createdAt: 'desc' }, // 기본 정렬: 최신 생성일 순
+    skip: options?.skip,
+    take: options?.take,
+    include: options?.include,
   });
   return projects;
 };

--- a/src/services/db-access-service/project.db.service.ts
+++ b/src/services/db-access-service/project.db.service.ts
@@ -1,0 +1,75 @@
+import prisma from '@/lib/prisma'; // Prisma 클라이언트 인스턴스
+import { Project, Prisma } from '@prisma/client'; // Prisma에서 생성된 타입들
+
+/**
+ * 데이터베이스에 새로운 프로젝트를 생성합니다.
+ * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
+ * @param projectData 생성할 프로젝트 데이터 (Prisma.ProjectCreateInput 타입)
+ * @returns 생성된 Project 객체
+ * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
+ */
+export const createProjectInDB = async (
+  projectData: Prisma.ProjectCreateInput
+): Promise<Project> => {
+  // try...catch 블록 없이, 에러는 호출한 곳으로 전파됩니다.
+  const newProject = await prisma.project.create({
+    data: projectData,
+  });
+  return newProject;
+};
+
+/**
+ * 주어진 ID로 특정 프로젝트를 조회합니다.
+ * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
+ * @param projectId 조회할 프로젝트의 ID
+ * @param includeRelations (선택적) 함께 로드할 관계 (예: { owner: true })
+ * @returns Project 객체 또는 null (찾지 못한 경우)
+ * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
+ */
+export const findProjectByIdFromDB = async (
+  projectId: number,
+  includeRelations?: Prisma.ProjectInclude
+): Promise<Project | null> => {
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    include: includeRelations,
+  });
+  return project;
+};
+
+/**
+ * 주어진 도메인명으로 프로젝트를 조회합니다.
+ * 도메인 중복 검사 등에 유용합니다.
+ * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
+ * @param domain 조회할 도메인명
+ * @returns Project 객체 또는 null (찾지 못한 경우)
+ * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
+ */
+export const findProjectByDomainFromDB = async (
+  domain: string
+): Promise<Project | null> => {
+  const project = await prisma.project.findUnique({
+    where: { domain: domain },
+  });
+  return project;
+};
+
+/**
+ * 특정 사용자가 소유한 모든 프로젝트 목록을 조회합니다.
+ * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
+ * @param ownerId 소유자의 ID
+ * @returns Project 객체의 배열
+ * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
+ */
+export const findProjectsByOwnerIdFromDB = async (
+  ownerId: number
+): Promise<Project[]> => {
+  const projects = await prisma.project.findMany({
+    where: { ownerId: ownerId },
+    orderBy: { createdAt: 'desc' }, // 예시: 최신 생성일 순으로 정렬
+  });
+  return projects;
+};
+
+// Project 모델과 관련된 다른 DB 접근 함수들은 필요에 따라 여기에 추가할 수 있습니다.
+// 예: updateProjectInDB, deleteProjectFromDB 등


### PR DESCRIPTION
# PR

## PR 요약
Project 모델에 대한 데이터베이스 접근 로직을 담당하는 ProjectDBService 모듈을 신규로 구현했습니다. 이를 통해 프로젝트 정보의 생성, 조회 기능을 제공하여 향후 프로젝트 관리 기능의 기반을 마련합니다.

- 현재 사용할 수 없는 모듈이며, 단위 테스트를 통과한 코드입니다. 나중에 구현된 모듈을 통합해서 통합 테스트를 진행할 계획입니다.

## 변경된 점
- 신규 파일 추가: src/db-access/project.db.service.ts
- Prisma 클라이언트를 사용하여 Project 모델과 상호작용하는 다음 함수들을 구현했습니다:
- createProjectInDB(data: Prisma.ProjectCreateInput): Promise<Project>: 새로운 프로젝트 레코드를 데이터베이스에 생성합니다.
- findProjectByIdFromDB(projectId: number, includeRelations?: Prisma.ProjectInclude): Promise<Project | null>: 주어진 ID로 특정 프로젝트를 조회하며, 선택적으로 관계된 모델(예: owner) 정보를 함께 가져올 수 있습니다.
- findProjectByDomainFromDB(domain: string): Promise<Project | null>: 주어진 도메인명으로 프로젝트를 조회하여 도메인 중복 검사 등에 활용될 수 있습니다.
- findProjectsByOwnerIdFromDB(ownerId: number): Promise<Project[]>: 특정 사용자가 소유한 모든 프로젝트 목록을 최신순으로 조회합니다.
- 에러 처리: 각 DB 접근 함수는 try...catch 블록 없이 Prisma에서 발생하는 에러를 직접 상위 서비스 계층으로 전파하도록 구현하여, 에러 처리를 중앙화할 수 있도록 했습니다.
- 타입 안정성: Prisma에서 자동 생성된 타입(Project, Prisma.ProjectCreateInput 등)을 적극 활용하여 코드의 타입 안정성을 높였습니다.

## 이슈 번호

#58 