### PR TITLE
feat: 프로젝트 생성 기초 백엔드 구현

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,14 +1,17 @@
 // src/components/Header.tsx
-import styles from './Header.module.css'
+import styles from './Header.module.css';
+import { useRouter } from 'next/router';
 
 export default function Header() {
-    return (
-        <nav className={styles.nav}>
-            <div className={styles.logo}>Intellisia🥕</div>
-            <div className={styles.navRight}>
-                <div className={styles.profile}>
-                </div>
-            </div>
-        </nav>
-    )
+  const router = useRouter();
+  return (
+    <nav className={styles.nav}>
+      <div className={styles.logo}>
+        <button onClick={() => router.push('/dashboard')}>Intellisia🥕</button>
+      </div>
+      <div className={styles.navRight}>
+        <div className={styles.profile}></div>
+      </div>
+    </nav>
+  );
 }

--- a/src/pages/api/projects/create_project.ts
+++ b/src/pages/api/projects/create_project.ts
@@ -1,0 +1,93 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '@/lib/prisma';
+// import { getSession } from 'next-auth/react';
+
+interface CreateProjectRequest {
+  projectName: string;
+  description: string;
+  githubUrl: string;
+  domain: string;
+  defaultHelmValues: {
+    replicaCount: number;
+    service: {
+      targetPort: number;
+    };
+  };
+}
+
+interface ErrorResponse {
+  message: string;
+  error?: string;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ id: number; name: string } | ErrorResponse>
+) {
+  if (req.method !== 'POST') {
+    return res
+      .status(405)
+      .json({ message: 'Method not allowed' } as ErrorResponse);
+  }
+
+  try {
+    // TODO: 인증 관련 코드는 나중에 구현
+    // const session = await getSession({ req });
+    // if (!session?.user?.email) {
+    //   return res.status(401).json({ message: '인증이 필요합니다.' });
+    // }
+
+    // const user = await prisma.user.findUnique({
+    //   where: { email: session.user.email },
+    // });
+
+    // if (!user) {
+    //   return res.status(404).json({ message: '사용자를 찾을 수 없습니다.' });
+    // }
+
+    const { projectName, description, githubUrl, domain, defaultHelmValues } =
+      req.body as CreateProjectRequest;
+
+    // 기본값 설정
+    const defaultValues = {
+      ...defaultHelmValues,
+      service: {
+        port: 80,
+        type: 'ClusterIP',
+        ...defaultHelmValues.service,
+      },
+      resources: {
+        limits: {
+          cpu: '500m',
+          memory: '512Mi',
+        },
+        requests: {
+          cpu: '100m',
+          memory: '128Mi',
+        },
+      },
+    };
+
+    const project = await prisma.project.create({
+      data: {
+        name: projectName,
+        description: description || '',
+        githubUrl,
+        domain,
+        defaultHelmValues: defaultValues,
+        ownerId: 1, // 테스트용 하드코딩된 ownerId
+      },
+    });
+
+    return res.status(201).json({
+      id: project.id,
+      name: project.name,
+    });
+  } catch (error) {
+    console.error('프로젝트 생성 중 오류 발생:', error);
+    return res.status(500).json({
+      message: '프로젝트 생성 중 오류가 발생했습니다.',
+      error: error instanceof Error ? error.message : 'Unknown error',
+    } as ErrorResponse);
+  }
+}


### PR DESCRIPTION
# 프로젝트 생성 기초 백엔드 구현

## PR 요약
사용자가 항목을 입력하면 그 값을 그대로 DB의 project 테이블에 저장하는 백엔드

## 변경된 점

-(프론트)와 연동하는 src\pages\create-project.tsx(프론트)와 연동하는 src\pages\api\projects\create_project.ts (백엔드) 파일 생성
-사용자 인증과 관련된 코드는 현재 우선순위가 떨어진다고 판단하여 주석처리 했습니다.

- 추가로, 좌상단 로고를 클릭하면 대시보드 페이지로 이동하는 기능을 추가했습니다

## 이슈 번호
fix #74 