### PR TITLE
fix:UserDBService에 전체 사용자 조회 기능 추가 및 리팩토링

### DIFF
--- a/src/services/db-access-service/project.db.service.ts
+++ b/src/services/db-access-service/project.db.service.ts
@@ -11,7 +11,6 @@ import { Project, Prisma } from '@prisma/client'; // Prisma에서 생성된 타�
 export const createProjectInDB = async (
   projectData: Prisma.ProjectCreateInput
 ): Promise<Project> => {
-  // try...catch 블록 없이, 에러는 호출한 곳으로 전파됩니다.
   const newProject = await prisma.project.create({
     data: projectData,
   });
@@ -56,17 +55,53 @@ export const findProjectByDomainFromDB = async (
 
 /**
  * 특정 사용자가 소유한 모든 프로젝트 목록을 조회합니다.
+ * (예: "내 프로젝트" 목록 기능에 사용)
  * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
  * @param ownerId 소유자의 ID
+ * @param options (선택적) 정렬, 페이지네이션, 관계 포함 등의 옵션
  * @returns Project 객체의 배열
  * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
  */
 export const findProjectsByOwnerIdFromDB = async (
-  ownerId: number
+  ownerId: number,
+  options?: {
+    orderBy?: Prisma.ProjectOrderByWithRelationInput | Prisma.ProjectOrderByWithRelationInput[];
+    skip?: number;
+    take?: number;
+    include?: Prisma.ProjectInclude;
+  }
 ): Promise<Project[]> => {
   const projects = await prisma.project.findMany({
     where: { ownerId: ownerId },
-    orderBy: { createdAt: 'desc' }, // 예시: 최신 생성일 순으로 정렬
+    orderBy: options?.orderBy || { createdAt: 'desc' },
+    skip: options?.skip,
+    take: options?.take,
+    include: options?.include,
+  });
+  return projects;
+};
+
+/**
+ * 시스템에 있는 모든 프로젝트 목록을 조회합니다.
+ * 로그인한 사용자가 (권한 구분 없이) 모든 프로젝트를 볼 수 있는 시나리오에 사용됩니다.
+ * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
+ * @param options (선택적) 정렬, 페이지네이션, 관계 포함 등의 옵션 (예: 소유자 정보 포함)
+ * @returns Project 객체의 배열
+ * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
+ */
+export const findAllProjectsDB = async (
+  options?: {
+    orderBy?: Prisma.ProjectOrderByWithRelationInput | Prisma.ProjectOrderByWithRelationInput[];
+    skip?: number;
+    take?: number;
+    include?: Prisma.ProjectInclude; // 예: { owner: { select: { id: true, name: true, email: true } } }
+  }
+): Promise<Project[]> => {
+  const projects = await prisma.project.findMany({
+    orderBy: options?.orderBy || { createdAt: 'desc' }, // 기본 정렬: 최신 생성일 순
+    skip: options?.skip,
+    take: options?.take,
+    include: options?.include,
   });
   return projects;
 };

--- a/src/services/db-access-service/project.db.service.ts
+++ b/src/services/db-access-service/project.db.service.ts
@@ -6,7 +6,6 @@ import { Project, Prisma } from '@prisma/client'; // Prisma에서 생성된 타�
  * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
  * @param projectData 생성할 프로젝트 데이터 (Prisma.ProjectCreateInput 타입)
  * @returns 생성된 Project 객체
- * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
  */
 export const createProjectInDB = async (
   projectData: Prisma.ProjectCreateInput
@@ -18,31 +17,11 @@ export const createProjectInDB = async (
 };
 
 /**
- * 주어진 ID로 특정 프로젝트를 조회합니다.
- * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
- * @param projectId 조회할 프로젝트의 ID
- * @param includeRelations (선택적) 함께 로드할 관계 (예: { owner: true })
- * @returns Project 객체 또는 null (찾지 못한 경우)
- * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
- */
-export const findProjectByIdFromDB = async (
-  projectId: number,
-  includeRelations?: Prisma.ProjectInclude
-): Promise<Project | null> => {
-  const project = await prisma.project.findUnique({
-    where: { id: projectId },
-    include: includeRelations,
-  });
-  return project;
-};
-
-/**
  * 주어진 도메인명으로 프로젝트를 조회합니다.
- * 도메인 중복 검사 등에 유용합니다.
+ * 프로젝트 생성 시 도메인 중복 검사에 사용됩니다.
  * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
  * @param domain 조회할 도메인명
  * @returns Project 객체 또는 null (찾지 못한 경우)
- * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
  */
 export const findProjectByDomainFromDB = async (
   domain: string
@@ -52,59 +31,3 @@ export const findProjectByDomainFromDB = async (
   });
   return project;
 };
-
-/**
- * 특정 사용자가 소유한 모든 프로젝트 목록을 조회합니다.
- * (예: "내 프로젝트" 목록 기능에 사용)
- * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
- * @param ownerId 소유자의 ID
- * @param options (선택적) 정렬, 페이지네이션, 관계 포함 등의 옵션
- * @returns Project 객체의 배열
- * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
- */
-export const findProjectsByOwnerIdFromDB = async (
-  ownerId: number,
-  options?: {
-    orderBy?: Prisma.ProjectOrderByWithRelationInput | Prisma.ProjectOrderByWithRelationInput[];
-    skip?: number;
-    take?: number;
-    include?: Prisma.ProjectInclude;
-  }
-): Promise<Project[]> => {
-  const projects = await prisma.project.findMany({
-    where: { ownerId: ownerId },
-    orderBy: options?.orderBy || { createdAt: 'desc' },
-    skip: options?.skip,
-    take: options?.take,
-    include: options?.include,
-  });
-  return projects;
-};
-
-/**
- * 시스템에 있는 모든 프로젝트 목록을 조회합니다.
- * 로그인한 사용자가 (권한 구분 없이) 모든 프로젝트를 볼 수 있는 시나리오에 사용됩니다.
- * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
- * @param options (선택적) 정렬, 페이지네이션, 관계 포함 등의 옵션 (예: 소유자 정보 포함)
- * @returns Project 객체의 배열
- * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
- */
-export const findAllProjectsDB = async (
-  options?: {
-    orderBy?: Prisma.ProjectOrderByWithRelationInput | Prisma.ProjectOrderByWithRelationInput[];
-    skip?: number;
-    take?: number;
-    include?: Prisma.ProjectInclude; // 예: { owner: { select: { id: true, name: true, email: true } } }
-  }
-): Promise<Project[]> => {
-  const projects = await prisma.project.findMany({
-    orderBy: options?.orderBy || { createdAt: 'desc' }, // 기본 정렬: 최신 생성일 순
-    skip: options?.skip,
-    take: options?.take,
-    include: options?.include,
-  });
-  return projects;
-};
-
-// Project 모델과 관련된 다른 DB 접근 함수들은 필요에 따라 여기에 추가할 수 있습니다.
-// 예: updateProjectInDB, deleteProjectFromDB 등

--- a/src/services/db-access-service/project.db.service.ts
+++ b/src/services/db-access-service/project.db.service.ts
@@ -6,10 +6,6 @@ import { Project, Prisma } from '@prisma/client'; // Prisma에서 생성된 타�
  * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
  * @param projectData 생성할 프로젝트 데이터 (Prisma.ProjectCreateInput 타입)
  * @returns 생성된 Project 객체
-<<<<<<< HEAD
-=======
- * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
->>>>>>> main
  */
 export const createProjectInDB = async (
   projectData: Prisma.ProjectCreateInput
@@ -21,39 +17,11 @@ export const createProjectInDB = async (
 };
 
 /**
-<<<<<<< HEAD
  * 주어진 도메인명으로 프로젝트를 조회합니다.
  * 프로젝트 생성 시 도메인 중복 검사에 사용됩니다.
  * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
  * @param domain 조회할 도메인명
  * @returns Project 객체 또는 null (찾지 못한 경우)
-=======
- * 주어진 ID로 특정 프로젝트를 조회합니다.
- * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
- * @param projectId 조회할 프로젝트의 ID
- * @param includeRelations (선택적) 함께 로드할 관계 (예: { owner: true })
- * @returns Project 객체 또는 null (찾지 못한 경우)
- * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
- */
-export const findProjectByIdFromDB = async (
-  projectId: number,
-  includeRelations?: Prisma.ProjectInclude
-): Promise<Project | null> => {
-  const project = await prisma.project.findUnique({
-    where: { id: projectId },
-    include: includeRelations,
-  });
-  return project;
-};
-
-/**
- * 주어진 도메인명으로 프로젝트를 조회합니다.
- * 도메인 중복 검사 등에 유용합니다.
- * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
- * @param domain 조회할 도메인명
- * @returns Project 객체 또는 null (찾지 못한 경우)
- * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
->>>>>>> main
  */
 export const findProjectByDomainFromDB = async (
   domain: string
@@ -62,64 +30,4 @@ export const findProjectByDomainFromDB = async (
     where: { domain: domain },
   });
   return project;
-<<<<<<< HEAD
 };
-=======
-};
-
-/**
- * 특정 사용자가 소유한 모든 프로젝트 목록을 조회합니다.
- * (예: "내 프로젝트" 목록 기능에 사용)
- * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
- * @param ownerId 소유자의 ID
- * @param options (선택적) 정렬, 페이지네이션, 관계 포함 등의 옵션
- * @returns Project 객체의 배열
- * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
- */
-export const findProjectsByOwnerIdFromDB = async (
-  ownerId: number,
-  options?: {
-    orderBy?: Prisma.ProjectOrderByWithRelationInput | Prisma.ProjectOrderByWithRelationInput[];
-    skip?: number;
-    take?: number;
-    include?: Prisma.ProjectInclude;
-  }
-): Promise<Project[]> => {
-  const projects = await prisma.project.findMany({
-    where: { ownerId: ownerId },
-    orderBy: options?.orderBy || { createdAt: 'desc' },
-    skip: options?.skip,
-    take: options?.take,
-    include: options?.include,
-  });
-  return projects;
-};
-
-/**
- * 시스템에 있는 모든 프로젝트 목록을 조회합니다.
- * 로그인한 사용자가 (권한 구분 없이) 모든 프로젝트를 볼 수 있는 시나리오에 사용됩니다.
- * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
- * @param options (선택적) 정렬, 페이지네이션, 관계 포함 등의 옵션 (예: 소유자 정보 포함)
- * @returns Project 객체의 배열
- * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
- */
-export const findAllProjectsDB = async (
-  options?: {
-    orderBy?: Prisma.ProjectOrderByWithRelationInput | Prisma.ProjectOrderByWithRelationInput[];
-    skip?: number;
-    take?: number;
-    include?: Prisma.ProjectInclude; // 예: { owner: { select: { id: true, name: true, email: true } } }
-  }
-): Promise<Project[]> => {
-  const projects = await prisma.project.findMany({
-    orderBy: options?.orderBy || { createdAt: 'desc' }, // 기본 정렬: 최신 생성일 순
-    skip: options?.skip,
-    take: options?.take,
-    include: options?.include,
-  });
-  return projects;
-};
-
-// Project 모델과 관련된 다른 DB 접근 함수들은 필요에 따라 여기에 추가할 수 있습니다.
-// 예: updateProjectInDB, deleteProjectFromDB 등
->>>>>>> main

--- a/src/services/db-access-service/project.db.service.ts
+++ b/src/services/db-access-service/project.db.service.ts
@@ -1,0 +1,75 @@
+import prisma from '@/lib/prisma'; // Prisma 클라이언트 인스턴스
+import { Project, Prisma } from '@prisma/client'; // Prisma에서 생성된 타입들
+
+/**
+ * 데이터베이스에 새로운 프로젝트를 생성합니다.
+ * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
+ * @param projectData 생성할 프로젝트 데이터 (Prisma.ProjectCreateInput 타입)
+ * @returns 생성된 Project 객체
+ * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
+ */
+export const createProjectInDB = async (
+  projectData: Prisma.ProjectCreateInput
+): Promise<Project> => {
+  // try...catch 블록 없이, 에러는 호출한 곳으로 전파됩니다.
+  const newProject = await prisma.project.create({
+    data: projectData,
+  });
+  return newProject;
+};
+
+/**
+ * 주어진 ID로 특정 프로젝트를 조회합니다.
+ * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
+ * @param projectId 조회할 프로젝트의 ID
+ * @param includeRelations (선택적) 함께 로드할 관계 (예: { owner: true })
+ * @returns Project 객체 또는 null (찾지 못한 경우)
+ * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
+ */
+export const findProjectByIdFromDB = async (
+  projectId: number,
+  includeRelations?: Prisma.ProjectInclude
+): Promise<Project | null> => {
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    include: includeRelations,
+  });
+  return project;
+};
+
+/**
+ * 주어진 도메인명으로 프로젝트를 조회합니다.
+ * 도메인 중복 검사 등에 유용합니다.
+ * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
+ * @param domain 조회할 도메인명
+ * @returns Project 객체 또는 null (찾지 못한 경우)
+ * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
+ */
+export const findProjectByDomainFromDB = async (
+  domain: string
+): Promise<Project | null> => {
+  const project = await prisma.project.findUnique({
+    where: { domain: domain },
+  });
+  return project;
+};
+
+/**
+ * 특정 사용자가 소유한 모든 프로젝트 목록을 조회합니다.
+ * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
+ * @param ownerId 소유자의 ID
+ * @returns Project 객체의 배열
+ * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
+ */
+export const findProjectsByOwnerIdFromDB = async (
+  ownerId: number
+): Promise<Project[]> => {
+  const projects = await prisma.project.findMany({
+    where: { ownerId: ownerId },
+    orderBy: { createdAt: 'desc' }, // 예시: 최신 생성일 순으로 정렬
+  });
+  return projects;
+};
+
+// Project 모델과 관련된 다른 DB 접근 함수들은 필요에 따라 여기에 추가할 수 있습니다.
+// 예: updateProjectInDB, deleteProjectFromDB 등

--- a/src/services/db-access-service/user.db.service.ts
+++ b/src/services/db-access-service/user.db.service.ts
@@ -1,46 +1,107 @@
-import prisma from '@/lib/prisma'; // Prisma Client 인스턴스 import
-import { User, Prisma } from '@prisma/client'; // Prisma에서 생성된 User 타입 및 Prisma 네임스페이스 import
+import prisma from '@/lib/prisma'; // Prisma 클라이언트 인스턴스
+import { User, Prisma } from '@prisma/client'; // Prisma에서 생성된 타입들
+
+/**
+ * 새로운 사용자를 데이터베이스에 생성합니다.
+ * (참고: 현재 "프로젝트 생성" 기능에서는 직접 사용되지 않으나, 향후 사용자 가입 등 기능 확장 시 필요)
+ * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
+ * @param userData 생성할 사용자 데이터 (Prisma.UserCreateInput 타입)
+ * @returns 생성된 User 객체
+ * @throws PrismaClientKnownRequestError (예: 이메일 중복 시 P2002) 등 DB 관련 에러
+ */
+export const createUserInDB = async (
+  userData: Prisma.UserCreateInput
+): Promise<User> => {
+  const newUser = await prisma.user.create({
+    data: userData,
+  });
+  return newUser;
+};
 
 /**
  * 주어진 ID로 특정 사용자를 조회합니다.
- * 에러 발생 시 호출한 상위 서비스로 에러를 전파합니다.
- * @param userId 조회할 사용자의 ID (숫자)
- * @param includeRelations (선택적) 함께 로드할 관계형 데이터 (예: 사용자가 생성한 프로젝트 목록)
- * @returns User 객체 또는 null (사용자를 찾지 못한 경우)
+ * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
+ * @param userId 조회할 사용자의 ID
+ * @param includeRelations (선택적) 함께 로드할 관계 (예: { projects: true })
+ * @returns User 객체 또는 null (찾지 못한 경우)
  * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
  */
-export const findUserById = async (
+export const findUserByIdFromDB = async (
   userId: number,
-  includeRelations?: Prisma.UserInclude // 관계형 데이터를 포함하기 위한 타입
+  includeRelations: { projects?: boolean } = { projects: true }
 ): Promise<User | null> => {
-  // try...catch 블록 제거, 에러는 상위로 전파됨
   const user = await prisma.user.findUnique({
-    where: {
-      id: userId,
-    },
-    include: includeRelations, // 예: { projects: true }
+    where: { id: userId },
+    include: includeRelations.projects ? { projects: true } : undefined,
   });
   return user;
 };
 
 /**
  * 주어진 이메일 주소로 특정 사용자를 조회합니다.
- * 에러 발생 시 호출한 상위 서비스로 에러를 전파합니다.
- * @param email 조회할 사용자의 이메일 주소 (문자열)
- * @returns User 객체 또는 null (사용자를 찾지 못한 경우)
+ * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
+ * @param email 조회할 사용자의 이메일 주소
+ * @param includeRelations (선택적) 함께 로드할 관계 (예: { projects: true })
+ * @returns User 객체 또는 null (찾지 못한 경우)
  * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
  */
-export const findUserByEmail = async (
-  email: string
+export const findUserByEmailFromDB = async (
+  email: string,
+  includeRelations: { projects?: boolean } = { projects: true }
 ): Promise<User | null> => {
-  // try...catch 블록 제거, 에러는 상위로 전파됨
   const user = await prisma.user.findUnique({
-    where: {
-      email: email,
-    },
+    where: { email: email },
+    include: includeRelations.projects ? { projects: true } : undefined,
   });
   return user;
 };
 
-// createUser 및 updateUser 함수는 현재 요구사항에서 제외되었습니다.
-// 향후 사용자 가입, 프로필 수정 등의 기능이 필요할 때 추가할 수 있습니다.
+/**
+ * 시스템의 모든 사용자 목록을 조회합니다.
+ * (예: 관리자 페이지의 사용자 목록 기능에 사용)
+ * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
+ * @param options (선택적) 정렬, 페이지네이션, 관계 포함 등의 옵션
+ * @returns User 객체의 배열
+ * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
+ */
+export const findAllUsersDB = async (
+  options?: {
+    orderBy?: Prisma.UserOrderByWithRelationInput | Prisma.UserOrderByWithRelationInput[];
+    skip?: number;
+    take?: number;
+    where?: Prisma.UserWhereInput; // 필터링 조건 추가
+    include?: Prisma.UserInclude;
+  }
+): Promise<User[]> => {
+  const users = await prisma.user.findMany({
+    where: options?.where,
+    orderBy: options?.orderBy || { createdAt: 'desc' }, // 기본 정렬: 최신 가입일 순
+    skip: options?.skip,
+    take: options?.take,
+    include: options?.include,
+  });
+  return users;
+};
+
+/**
+ * 특정 사용자의 정보를 업데이트합니다.
+ * (참고: 현재 "프로젝트 생성" 기능에서는 직접 사용되지 않으나, 향후 프로필 수정 등 기능 확장 시 필요)
+ * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
+ * @param userId 업데이트할 사용자의 ID
+ * @param updateData 업데이트할 사용자 데이터 (Prisma.UserUpdateInput 타입)
+ * @returns 업데이트된 User 객체
+ * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
+ */
+export const updateUserInDB = async (
+  userId: number,
+  updateData: Prisma.UserUpdateInput
+): Promise<User> => {
+  const updatedUser = await prisma.user.update({
+    where: { id: userId },
+    data: updateData,
+  });
+  return updatedUser;
+};
+
+// User 모델과 관련된 다른 DB 접근 함수들은 필요에 따라 여기에 추가할 수 있습니다.
+// 예: deleteUserFromDB 등

--- a/src/services/db-access-service/user.db.service.ts
+++ b/src/services/db-access-service/user.db.service.ts
@@ -1,107 +1,18 @@
-import prisma from '@/lib/prisma'; // Prisma 클라이언트 인스턴스
-import { User, Prisma } from '@prisma/client'; // Prisma에서 생성된 타입들
-
-/**
- * 새로운 사용자를 데이터베이스에 생성합니다.
- * (참고: 현재 "프로젝트 생성" 기능에서는 직접 사용되지 않으나, 향후 사용자 가입 등 기능 확장 시 필요)
- * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
- * @param userData 생성할 사용자 데이터 (Prisma.UserCreateInput 타입)
- * @returns 생성된 User 객체
- * @throws PrismaClientKnownRequestError (예: 이메일 중복 시 P2002) 등 DB 관련 에러
- */
-export const createUserInDB = async (
-  userData: Prisma.UserCreateInput
-): Promise<User> => {
-  const newUser = await prisma.user.create({
-    data: userData,
-  });
-  return newUser;
-};
+import prisma from '@/lib/prisma';
+import { User } from '@prisma/client';
 
 /**
  * 주어진 ID로 특정 사용자를 조회합니다.
- * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
+ * 프로젝트 생성 시 소유자(owner)의 존재를 확인하는 데 사용됩니다.
+ * 에러 발생 시 호출한 상위 서비스로 에러를 전파합니다.
  * @param userId 조회할 사용자의 ID
- * @param includeRelations (선택적) 함께 로드할 관계 (예: { projects: true })
- * @returns User 객체 또는 null (찾지 못한 경우)
- * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
+ * @returns User 객체 또는 null (사용자를 찾지 못한 경우)
  */
 export const findUserByIdFromDB = async (
-  userId: number,
-  includeRelations: { projects?: boolean } = { projects: true }
+  userId: number
 ): Promise<User | null> => {
   const user = await prisma.user.findUnique({
     where: { id: userId },
-    include: includeRelations.projects ? { projects: true } : undefined,
   });
   return user;
 };
-
-/**
- * 주어진 이메일 주소로 특정 사용자를 조회합니다.
- * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
- * @param email 조회할 사용자의 이메일 주소
- * @param includeRelations (선택적) 함께 로드할 관계 (예: { projects: true })
- * @returns User 객체 또는 null (찾지 못한 경우)
- * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
- */
-export const findUserByEmailFromDB = async (
-  email: string,
-  includeRelations: { projects?: boolean } = { projects: true }
-): Promise<User | null> => {
-  const user = await prisma.user.findUnique({
-    where: { email: email },
-    include: includeRelations.projects ? { projects: true } : undefined,
-  });
-  return user;
-};
-
-/**
- * 시스템의 모든 사용자 목록을 조회합니다.
- * (예: 관리자 페이지의 사용자 목록 기능에 사용)
- * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
- * @param options (선택적) 정렬, 페이지네이션, 관계 포함 등의 옵션
- * @returns User 객체의 배열
- * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
- */
-export const findAllUsersDB = async (
-  options?: {
-    orderBy?: Prisma.UserOrderByWithRelationInput | Prisma.UserOrderByWithRelationInput[];
-    skip?: number;
-    take?: number;
-    where?: Prisma.UserWhereInput; // 필터링 조건 추가
-    include?: Prisma.UserInclude;
-  }
-): Promise<User[]> => {
-  const users = await prisma.user.findMany({
-    where: options?.where,
-    orderBy: options?.orderBy || { createdAt: 'desc' }, // 기본 정렬: 최신 가입일 순
-    skip: options?.skip,
-    take: options?.take,
-    include: options?.include,
-  });
-  return users;
-};
-
-/**
- * 특정 사용자의 정보를 업데이트합니다.
- * (참고: 현재 "프로젝트 생성" 기능에서는 직접 사용되지 않으나, 향후 프로필 수정 등 기능 확장 시 필요)
- * 에러 발생 시 호출한 서비스로 에러를 전파합니다.
- * @param userId 업데이트할 사용자의 ID
- * @param updateData 업데이트할 사용자 데이터 (Prisma.UserUpdateInput 타입)
- * @returns 업데이트된 User 객체
- * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능합니다.
- */
-export const updateUserInDB = async (
-  userId: number,
-  updateData: Prisma.UserUpdateInput
-): Promise<User> => {
-  const updatedUser = await prisma.user.update({
-    where: { id: userId },
-    data: updateData,
-  });
-  return updatedUser;
-};
-
-// User 모델과 관련된 다른 DB 접근 함수들은 필요에 따라 여기에 추가할 수 있습니다.
-// 예: deleteUserFromDB 등

--- a/src/services/db-access-service/user.db.service.ts
+++ b/src/services/db-access-service/user.db.service.ts
@@ -90,7 +90,7 @@ export const findAllUsersDB = async (
  * @param userId 업데이트할 사용자의 ID
  * @param updateData 업데이트할 사용자 데이터 (Prisma.UserUpdateInput 타입)
  * @returns 업데이트된 User 객체
- * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능
+ * @throws PrismaClientKnownRequestError 등 DB 관련 에러 발생 가능합니다.
  */
 export const updateUserInDB = async (
   userId: number,


### PR DESCRIPTION
# PR

## PR 요약
프로젝트 생성에 필수적인 User 및 Project 모델 DB 접근 서비스 최소 기능 구현을 목표로 방향성 수정

## 변경된 점
- ID로 사용자 조회. (프로젝트 생성 시 ownerId로 전달될 사용자의 존재 유무만 확인
- 새 프로젝트 레코드를 DB에 삽입. 
- 도메인명으로 프로젝트 조회.

## 이슈 번호
#58