### PR TITLE
feat,fix:신규 Project 생성 API (POST /api/projects) 구현 및 관련 타입 정의 수정

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,7 +22,7 @@ model User {
 model Project {
   id                Int                   @id @default(autoincrement())
   name              String
-  description       String
+  description       String?
   githubUrl         String
   domain            String                @unique
   createdAt         DateTime              @default(now())

--- a/src/dtos/project/toProjectDetailDto.ts
+++ b/src/dtos/project/toProjectDetailDto.ts
@@ -4,7 +4,7 @@ export function toProjectDetailDto(
   project: {
     id: number;
     name: string;
-    description: string;
+    description: string | null;
     githubUrl: string;
     domain: string;
     createdAt: Date;
@@ -19,7 +19,7 @@ export function toProjectDetailDto(
   return {
     id: project.id,
     name: project.name,
-    description: project.description,
+    description: project.description ?? 'null',
     githubUrl: project.githubUrl,
     domain: project.domain,
     createdAt: project.createdAt.toISOString(),

--- a/src/pages/api/projects/index.ts
+++ b/src/pages/api/projects/index.ts
@@ -1,0 +1,98 @@
+// src/pages/api/projects/index.ts
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '@/lib/prisma'; // Prisma 클라이언트
+import { Prisma } from '@prisma/client';
+import { z } from 'zod';
+import { findProjectByDomainFromDB, createProjectInDB } from '@/services/db-access-service/project.db.service';
+
+// 여기에 인증 관련 함수/미들웨어를 import 하거나 직접 구현합니다.
+// 예시: import { getUserIdFromRequest } from '@/lib/auth';
+// 임시로 userId를 하드코딩하거나, 실제 인증 로직으로 대체해야 합니다.
+const getUserIdFromRequest = async (req: NextApiRequest): Promise<number | null> => {
+  // 실제 인증 로직: 헤더의 토큰 검증, 세션 확인 등
+  // 예시: const session = await getSession({ req }); if (session?.user?.id) return session.user.id;
+  console.warn("주의: 임시 사용자 ID (1) 사용 중. 실제 인증 로직으로 교체 필요!");
+  return 1; // MVP를 위해 임시로 사용자 ID 1을 반환
+};
+
+
+// 요청 본문 유효성 검사를 위한 Zod 스키마 정의
+const projectCreateSchema = z.object({
+  projectName: z.string().min(1, { message: '프로젝트 이름은 필수입니다.' }),
+  description: z.string().optional(),
+  githubUrl: z.string().url({ message: '올바른 GitHub URL 형식이 아닙니다.' }).regex(/\.git$/, { message: 'GitHub URL은 .git으로 끝나야 합니다.' }),
+  derivedDomain: z.string().min(1, { message: '도메인 이름은 필수입니다.' })
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, { message: '도메인은 소문자 영숫자와 하이픈(-)만 사용 가능하며, 하이픈으로 시작하거나 끝날 수 없습니다.'}),
+  defaultHelmValues: z.object({
+    replicaCount: z.number().int().nonnegative({ message: '레플리카 수는 0 이상이어야 합니다.' }),
+    containerPort: z.number().int().min(1, { message: '컨테이너 포트는 1 이상이어야 합니다.' }).max(65535, { message: '컨테이너 포트는 65535 이하여야 합니다.' }),
+    // 필요에 따라 defaultHelmValues에 대한 추가 필드 정의
+  }).passthrough(), // 스키마에 정의되지 않은 추가 속성도 허용 (주의해서 사용)
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method === 'POST') {
+    try {
+      // 2. 인증 및 ownerId 확보
+      const ownerId = await getUserIdFromRequest(req);
+      if (!ownerId) {
+        return res.status(401).json({ message: '인증되지 않은 사용자입니다.' });
+      }
+
+      // 3. 요청 본문 파싱 및 유효성 검사
+      const validationResult = projectCreateSchema.safeParse(req.body);
+      if (!validationResult.success) {
+        return res.status(400).json({ message: '입력값 유효성 검사 실패', errors: validationResult.error.flatten().fieldErrors });
+      }
+      const validatedData = validationResult.data;
+
+      // 4. 비즈니스 로직 - 도메인 유일성 검증
+      const existingProjectByDomain = await findProjectByDomainFromDB(validatedData.derivedDomain + '.intellisia.app'); // 실제 사용할 전체 도메인명으로 검사
+      if (existingProjectByDomain) {
+        // 중요: 실제 도메인 생성 규칙에 따라 `derivedDomain`에 기본 도메인(.intellisia.app 등)을 결합하여 검사해야 합니다.
+        // 프론트엔드의 `derivedDomain` 필드와 `BASE_DOMAIN`을 참고하여 일관성 유지.
+        // 여기서는 예시로 '.intellisia.app'을 추가했습니다.
+        return res.status(409).json({ message: `이미 사용 중인 도메인입니다: ${validatedData.derivedDomain}.intellisia.app` });
+      }
+      
+      const fullDomain = `${validatedData.derivedDomain}.intellisia.app`; // 실제 저장될 전체 도메인
+
+      // 5. 데이터베이스 저장 로직 호출
+      const projectDataToSave: Prisma.ProjectCreateInput = {
+        name: validatedData.projectName,
+        description: validatedData.description,
+        githubUrl: validatedData.githubUrl,
+        domain: fullDomain, // 검증된 전체 도메인 저장
+        defaultHelmValues: validatedData.defaultHelmValues as Prisma.JsonObject, // Zod 객체를 Prisma.JsonObject로 타입 단언
+        owner: { // 'owner' 관계를 통해 User에 연결합니다.
+          connect: {
+            id: ownerId // ownerId는 인증된 사용자의 ID입니다.
+          }
+        },
+        // status: 'INITIALIZING', // 필요한 경우 주석 해제
+      };
+      
+      const newProject = await createProjectInDB(projectDataToSave);
+
+      // 6. 응답 처리 (성공)
+      return res.status(201).json({ message: '프로젝트가 성공적으로 생성되었습니다.', project: { id: newProject.id, name: newProject.name, domain: newProject.domain } });
+
+    } catch (error) {
+      console.error('프로젝트 생성 중 에러 발생:', error);
+      // 데이터베이스 관련 에러 또는 기타 예기치 않은 에러 처리
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        // 예: 고유 제약 조건 위반 (P2002) 등 Prisma 특정 에러 처리
+        // 이 경우는 도메인 중복 검사에서 이미 처리되었을 가능성이 높음
+        return res.status(409).json({ message: '데이터베이스 저장 중 오류가 발생했습니다. 입력값을 확인해주세요.' });
+      }
+      return res.status(500).json({ message: '프로젝트 생성 중 서버 내부 오류가 발생했습니다.' });
+    }
+  } else {
+    // POST가 아닌 다른 HTTP 메소드 요청은 허용하지 않음
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}

--- a/src/pages/api/projects/index.ts
+++ b/src/pages/api/projects/index.ts
@@ -1,6 +1,6 @@
 // src/pages/api/projects/index.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
-import prisma from '@/lib/prisma'; // Prisma 클라이언트
+// import prisma from '@/lib/prisma'; Prisma 클라이언트 (나중에 사용용)
 import { Prisma } from '@prisma/client';
 import { z } from 'zod';
 import { findProjectByDomainFromDB, createProjectInDB } from '@/services/db-access-service/project.db.service';
@@ -8,9 +8,10 @@ import { findProjectByDomainFromDB, createProjectInDB } from '@/services/db-acce
 // 여기에 인증 관련 함수/미들웨어를 import 하거나 직접 구현합니다.
 // 예시: import { getUserIdFromRequest } from '@/lib/auth';
 // 임시로 userId를 하드코딩하거나, 실제 인증 로직으로 대체해야 합니다.
-const getUserIdFromRequest = async (req: NextApiRequest): Promise<number | null> => {
+const getUserIdFromRequest = async (_req: NextApiRequest): Promise<number | null> => {
   // 실제 인증 로직: 헤더의 토큰 검증, 세션 확인 등
   // 예시: const session = await getSession({ req }); if (session?.user?.id) return session.user.id;
+  // 이 부분은 나중에 선우씨랑 논의해서 인증 로직 구현
   console.warn("주의: 임시 사용자 ID (1) 사용 중. 실제 인증 로직으로 교체 필요!");
   return 1; // MVP를 위해 임시로 사용자 ID 1을 반환
 };
@@ -74,7 +75,7 @@ export default async function handler(
         },
         // status: 'INITIALIZING', // 필요한 경우 주석 해제
       };
-      
+
       const newProject = await createProjectInDB(projectDataToSave);
 
       // 6. 응답 처리 (성공)

--- a/src/pages/api/projects/index.ts
+++ b/src/pages/api/projects/index.ts
@@ -8,7 +8,7 @@ import { findProjectByDomainFromDB, createProjectInDB } from '@/services/db-acce
 // 여기에 인증 관련 함수/미들웨어를 import 하거나 직접 구현합니다.
 // 예시: import { getUserIdFromRequest } from '@/lib/auth';
 // 임시로 userId를 하드코딩하거나, 실제 인증 로직으로 대체해야 합니다.
-const getUserIdFromRequest = async (_req: NextApiRequest): Promise<number | null> => {
+const getUserIdFromRequest = async (): Promise<number | null> => {
   // 실제 인증 로직: 헤더의 토큰 검증, 세션 확인 등
   // 예시: const session = await getSession({ req }); if (session?.user?.id) return session.user.id;
   // 이 부분은 나중에 선우씨랑 논의해서 인증 로직 구현

--- a/src/services/project.service.ts
+++ b/src/services/project.service.ts
@@ -1,126 +1,20 @@
-import prisma from '@/lib/prisma'; // Prisma 클라이언트 (트랜잭션 등에 필요할 수 있음)
-import { Project, User, Prisma as PrismaTypes, ProjectContributors } from '@prisma/client'; // Prisma 모델 타입
-import { ValidatedCreateProjectData } from '@/validators/project.validators'; // 유효성 검사 통과 데이터 타입
+// project.service.ts
+import { getProjectById } from '@/repositories/project.repository';
+import { getVersionsByProject } from '@/repositories/version.repository';
+import { toProjectDetailDto } from '@/dtos/project/toProjectDetailDto';
+import { VersionSummary } from '@/types/project';
 
-// --- 데이터 접근 계층(DAL) 또는 Repository 함수 import ---
-// 중요: 아래 경로는 실제 프로젝트 구조에 맞게 정확히 수정해야 합니다.
-import { findUserById } from '@/services/db-access-service/user.db.service'; // 또는 user.repository.ts
-import {
-  createProjectInDB,
-  findProjectByDomainFromDB,
-  findProjectByIdFromDB as getProjectById, // findProjectByIdFromDB를 getProjectById 별칭으로 사용
-} from '@/services/db-access-service/project.db.service'; // 또는 project.repository.ts
-import { getVersionsByProject } from '@/repositories/version.repository'; // 또는 version.db.service.ts
-
-// --- DTO 및 타입 import ---
-import { toProjectDetailDto } from '@/dtos/project/toProjectDetailDto'; // 실제 경로 확인
-import { VersionSummary } from '@/types/project'; // 실제 경로 확인
-
-// toProjectDetailDto가 기대하는 Project 타입 (owner와 contributors 포함)
-// Prisma.ProjectGetPayload를 사용하면 더 정확한 타입을 생성할 수 있습니다.
-// 예시 타입이며, 실제 toProjectDetailDto의 파라미터 타입에 맞춰야 합니다.
-type ProjectForDetailDto = Project & {
-  owner: Pick<User, 'id' | 'name' | 'email' | 'avatarUrl'> | null; // User의 일부 필드만 선택
-  contributors: Array<{
-    user: Pick<User, 'id' | 'name' | 'email' | 'avatarUrl'> | null; // User의 일부 필드만 선택
-    // ProjectContributors 모델의 다른 필드가 필요하다면 여기에 추가
-  }>;
-};
-
-
-// ========================================================================
-// 기존 코드: 프로젝트 상세 정보 조회 (협업 환경 코드 - 수정됨)
-// ========================================================================
 export const getProjectDetail = async (
   projectId: number,
   sort: 'asc' | 'desc'
 ) => {
-  const includeOptions: PrismaTypes.ProjectInclude = {
-    owner: {
-      select: {
-        id: true,
-        name: true,
-        email: true,
-        avatarUrl: true,
-      },
-    },
-    contributors: {
-      select: {
-        user: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-            avatarUrl: true,
-          },
-        },
-      },
-    },
-  };
-
-  const project = await getProjectById(projectId, includeOptions);
-
-  if (!project) {
-    return null;
-  }
+  const project = await getProjectById(projectId);
+  if (!project) return null;
 
   const versions: VersionSummary[] = await getVersionsByProject(
     projectId,
     sort
   );
 
-  // toProjectDetailDto가 위에서 정의한 ProjectForDetailDto 또는
-  // Prisma.ProjectGetPayload<{ include: typeof includeOptions }> 타입과 호환되어야 합니다.
-  return toProjectDetailDto(project as ProjectForDetailDto, versions);
-};
-
-// ========================================================================
-// 새로 추가된 코드: 신규 프로젝트 생성
-// ========================================================================
-/**
- * 새로운 프로젝트를 생성합니다.
- * 유효성 검사를 통과한 데이터를 입력받아 소유자 확인, 도메인 중복 검사를 거친 후
- * 데이터베이스에 프로젝트를 저장합니다.
- *
- * @param validatedData 유효성 검사를 통과한 프로젝트 생성 데이터.
- * @param ownerId 프로젝트 소유자(User)의 ID.
- * @returns 생성된 Project 객체.
- * @throws Error 사용자를 찾을 수 없거나, 도메인이 이미 사용 중이거나, DB 작업 실패 시.
- */
-export const createNewProject = async (
-  validatedData: ValidatedCreateProjectData,
-  ownerId: number
-): Promise<Project> => {
-  // 1. 소유자(User) 존재 유무 확인
-  const owner = await findUserById(ownerId);
-  if (!owner) {
-    // 실제 애플리케이션에서는 NotFoundError 등 구체적인 커스텀 에러를 사용하는 것이 좋습니다.
-    throw new Error(`프로젝트 소유자 정보를 찾을 수 없습니다 (ID: ${ownerId}).`);
-  }
-
-  // 2. 도메인 중복 확인
-  const existingProjectWithDomain = await findProjectByDomainFromDB(
-    validatedData.domain
-  );
-  if (existingProjectWithDomain) {
-    // 실제 애플리케이션에서는 ConflictError 등 구체적인 커스텀 에러를 사용하는 것이 좋습니다.
-    throw new Error(`이미 사용 중인 도메인입니다: ${validatedData.domain}`);
-  }
-
-  // 3. DB 저장용 데이터 최종 준비
-  const projectDataForDb: PrismaTypes.ProjectCreateInput = {
-    name: validatedData.projectName,
-    description: validatedData.description || '',
-    githubUrl: validatedData.githubUrl,
-    domain: validatedData.domain,
-    defaultHelmValues: validatedData.defaultHelmValues, // Zod에서 이미 올바른 객체 구조로 검증됨
-    owner: { // 관계 필드를 통해 User와 연결
-      connect: { id: ownerId },
-    },
-  };
-
-  // 4. 데이터베이스에 Project 레코드 생성
-  const newProject = await createProjectInDB(projectDataForDb);
-
-  return newProject;
+  return toProjectDetailDto(project, versions);
 };

--- a/src/services/project.service.ts
+++ b/src/services/project.service.ts
@@ -1,19 +1,126 @@
-import { getProjectById } from '@/repositories/project.repository';
-import { getVersionsByProject } from '@/repositories/version.repository';
-import { toProjectDetailDto } from '@/dtos/project/toProjectDetailDto';
-import { VersionSummary } from '@/types/project';
+import prisma from '@/lib/prisma'; // Prisma 클라이언트 (트랜잭션 등에 필요할 수 있음)
+import { Project, User, Prisma as PrismaTypes, ProjectContributors } from '@prisma/client'; // Prisma 모델 타입
+import { ValidatedCreateProjectData } from '@/validators/project.validators'; // 유효성 검사 통과 데이터 타입
 
+// --- 데이터 접근 계층(DAL) 또는 Repository 함수 import ---
+// 중요: 아래 경로는 실제 프로젝트 구조에 맞게 정확히 수정해야 합니다.
+import { findUserById } from '@/services/db-access-service/user.db.service'; // 또는 user.repository.ts
+import {
+  createProjectInDB,
+  findProjectByDomainFromDB,
+  findProjectByIdFromDB as getProjectById, // findProjectByIdFromDB를 getProjectById 별칭으로 사용
+} from '@/services/db-access-service/project.db.service'; // 또는 project.repository.ts
+import { getVersionsByProject } from '@/repositories/version.repository'; // 또는 version.db.service.ts
+
+// --- DTO 및 타입 import ---
+import { toProjectDetailDto } from '@/dtos/project/toProjectDetailDto'; // 실제 경로 확인
+import { VersionSummary } from '@/types/project'; // 실제 경로 확인
+
+// toProjectDetailDto가 기대하는 Project 타입 (owner와 contributors 포함)
+// Prisma.ProjectGetPayload를 사용하면 더 정확한 타입을 생성할 수 있습니다.
+// 예시 타입이며, 실제 toProjectDetailDto의 파라미터 타입에 맞춰야 합니다.
+type ProjectForDetailDto = Project & {
+  owner: Pick<User, 'id' | 'name' | 'email' | 'avatarUrl'> | null; // User의 일부 필드만 선택
+  contributors: Array<{
+    user: Pick<User, 'id' | 'name' | 'email' | 'avatarUrl'> | null; // User의 일부 필드만 선택
+    // ProjectContributors 모델의 다른 필드가 필요하다면 여기에 추가
+  }>;
+};
+
+
+// ========================================================================
+// 기존 코드: 프로젝트 상세 정보 조회 (협업 환경 코드 - 수정됨)
+// ========================================================================
 export const getProjectDetail = async (
   projectId: number,
   sort: 'asc' | 'desc'
 ) => {
-  const project = await getProjectById(projectId);
-  if (!project) return null;
+  const includeOptions: PrismaTypes.ProjectInclude = {
+    owner: {
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        avatarUrl: true,
+      },
+    },
+    contributors: {
+      select: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            avatarUrl: true,
+          },
+        },
+      },
+    },
+  };
+
+  const project = await getProjectById(projectId, includeOptions);
+
+  if (!project) {
+    return null;
+  }
 
   const versions: VersionSummary[] = await getVersionsByProject(
     projectId,
     sort
   );
 
-  return toProjectDetailDto(project, versions);
+  // toProjectDetailDto가 위에서 정의한 ProjectForDetailDto 또는
+  // Prisma.ProjectGetPayload<{ include: typeof includeOptions }> 타입과 호환되어야 합니다.
+  return toProjectDetailDto(project as ProjectForDetailDto, versions);
+};
+
+// ========================================================================
+// 새로 추가된 코드: 신규 프로젝트 생성
+// ========================================================================
+/**
+ * 새로운 프로젝트를 생성합니다.
+ * 유효성 검사를 통과한 데이터를 입력받아 소유자 확인, 도메인 중복 검사를 거친 후
+ * 데이터베이스에 프로젝트를 저장합니다.
+ *
+ * @param validatedData 유효성 검사를 통과한 프로젝트 생성 데이터.
+ * @param ownerId 프로젝트 소유자(User)의 ID.
+ * @returns 생성된 Project 객체.
+ * @throws Error 사용자를 찾을 수 없거나, 도메인이 이미 사용 중이거나, DB 작업 실패 시.
+ */
+export const createNewProject = async (
+  validatedData: ValidatedCreateProjectData,
+  ownerId: number
+): Promise<Project> => {
+  // 1. 소유자(User) 존재 유무 확인
+  const owner = await findUserById(ownerId);
+  if (!owner) {
+    // 실제 애플리케이션에서는 NotFoundError 등 구체적인 커스텀 에러를 사용하는 것이 좋습니다.
+    throw new Error(`프로젝트 소유자 정보를 찾을 수 없습니다 (ID: ${ownerId}).`);
+  }
+
+  // 2. 도메인 중복 확인
+  const existingProjectWithDomain = await findProjectByDomainFromDB(
+    validatedData.domain
+  );
+  if (existingProjectWithDomain) {
+    // 실제 애플리케이션에서는 ConflictError 등 구체적인 커스텀 에러를 사용하는 것이 좋습니다.
+    throw new Error(`이미 사용 중인 도메인입니다: ${validatedData.domain}`);
+  }
+
+  // 3. DB 저장용 데이터 최종 준비
+  const projectDataForDb: PrismaTypes.ProjectCreateInput = {
+    name: validatedData.projectName,
+    description: validatedData.description || '',
+    githubUrl: validatedData.githubUrl,
+    domain: validatedData.domain,
+    defaultHelmValues: validatedData.defaultHelmValues, // Zod에서 이미 올바른 객체 구조로 검증됨
+    owner: { // 관계 필드를 통해 User와 연결
+      connect: { id: ownerId },
+    },
+  };
+
+  // 4. 데이터베이스에 Project 레코드 생성
+  const newProject = await createProjectInDB(projectDataForDb);
+
+  return newProject;
 };


### PR DESCRIPTION
# PR

## PR 요약
"프로젝트 템플릿 페이지"의 핵심 기능인 신규 프로젝트 생성 API (POST /api/projects)를 구현하고, 이 과정에서 발생한 Prisma 관련 TypeScript 타입 오류들을 수정하여 시스템 안정성을 개선했습니다.

## 변경된 점
- API 구현 (src/pages/api/projects/index.ts):
POST /api/projects 엔드포인트 로직 (인증, 유효성 검사, DB 저장) 추가.
owner 관계 연결 방식 및 Prisma 타입 사용법 수정 (예: ProjectCreateInput, PrismaClientKnownRequestError).

- DB 스키마 변경 (prisma/schema.prisma):
Project 모델의 description 필드를 선택 사항(String?)으로 변경.

- 서비스 및 DTO 레이어 수정 (src/services/project.service.ts, src/dtos/project/toProjectDetailDto.ts):
DB 스키마 변경에 따라 description 필드 (string | null) 타입을 수용하도록 관련 DTO 및 서비스 로직 수정.

## 이슈 번호

#58 