### PR TITLE
fix: version 타입 오류 해결 및 dto 분리

### DIFF
--- a/src/dtos/versions/toVersionHeaderDto.ts
+++ b/src/dtos/versions/toVersionHeaderDto.ts
@@ -1,14 +1,4 @@
-import { Version } from '@prisma/client';
-import { VersionHeader } from '@/types/version';
-
-type VersionWithProjectAndAuthor = Version & {
-  author: { name: string };
-  project: {
-    id: number;
-    name: string;
-    owner: { name: string };
-  };
-};
+import { VersionWithProjectAndAuthor, VersionHeader } from '@/types/version';
 
 export const toVersionHeaderDto = (
   version: VersionWithProjectAndAuthor

--- a/src/pages/api/versions/[versionId]/index.ts
+++ b/src/pages/api/versions/[versionId]/index.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getVersionWithProject } from '@/repositories/version.repository';
 import { toVersionHeaderDto } from '@/dtos/versions/toVersionHeaderDto';
+import { VersionWithProjectAndAuthor } from '@/types/version';
 
 export default async function handler(
   req: NextApiRequest,
@@ -13,12 +14,9 @@ export default async function handler(
 
   try {
     const version = await getVersionWithProject(versionId);
+    if (!version) return res.status(404).json({ message: 'Version not found' });
 
-    if (!version) {
-      return res.status(404).json({ message: 'Version not found' });
-    }
-
-    const dto = toVersionHeaderDto(version);
+    const dto = toVersionHeaderDto(version as VersionWithProjectAndAuthor);
     return res.status(200).json(dto);
   } catch (error) {
     console.error('[GET /api/versions/:versionId]', error);

--- a/src/types/version.ts
+++ b/src/types/version.ts
@@ -1,3 +1,5 @@
+import { Version } from '@prisma/client';
+
 export interface VersionHeader {
   project: {
     id: number;
@@ -9,3 +11,12 @@ export interface VersionHeader {
     name: string;
   };
 }
+
+export type VersionWithProjectAndAuthor = Version & {
+  author: { name: string };
+  project: {
+    id: number;
+    name: string;
+    owner: { name: string };
+  };
+};


### PR DESCRIPTION
# PR

## PR 요약
- project.owner가 null로 추론되어서 타입 오류가 발생함
- 타입 단언으로 타입 오류 해결

## 변경된 점

## 이슈 번호
