### PR TITLE
infra: EC2 자동화 배포 시 불필요한 Docker 이미지 제거

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_PRIVATE_KEY }}
           script: |
-              docker system prune -a -f # 불필요한 Docker 이미지 및 컨테이너 제거
+              docker image prune -f # 사용하지 않는 이미지만 강제로 삭제
               docker pull ${{ secrets.DOCKERHUB_USERNAME }}/my-app:latest && \
               docker stop my-container || true && \
               docker rm my-container || true && \


### PR DESCRIPTION
# PR

## PR 요약
EC2 자동화 배포 시 디스크 용량이 5%씩 차는 문제가 발생하여 
EC2 자동화 배포 파이프라인에 불필요한 Docker 이미지 정리 추가

## 변경된 점
스크립트에 한줄 추가 docker system prune -f 

## 이슈 번호
resolved #127 