### PR TITLE
fix: npm install 전에 .npmrc copy하도록 수정

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -4,6 +4,8 @@ FROM node:18-alpine
 # 컨테이너 내의 작업 디렉토리를 설정
 WORKDIR /app
 
+COPY .npmrc . 
+
 # package.json과 package-lock.json을 작업 디렉토리에 복사 (분리하여 캐싱 활용)
 COPY package*.json ./
 


### PR DESCRIPTION
# PR

## PR 요약
- npm install 전에 .npmrc copy하도록 수정했습니다.

## 변경된 점
changes

## 이슈 번호
resolved #150 