### PR TITLE
refactor:프로젝트 상세 페이지 description 필드 수정

### DIFF
--- a/src/services/version-service/initiate-version.service.ts
+++ b/src/services/version-service/initiate-version.service.ts
@@ -125,9 +125,13 @@ export async function initiateVersionInsideTx(
   });
 
   return await createVersionWithAutoName(tx, project.id, {
-    description: `"${branch}" 브랜치 실행 (최소 기능)`,
+    // 기존: `"${branch}" 브랜치 실행 (최소 기능)`
+    // 개선: 사용자 친화적인 설명
+    description: `${branch} 브랜치에서 배포된 버전입니다`,
     isCurrent: false,
-    imageTag: 'pending-build',
+    // 기존: 'pending-build'
+    // 개선: 더 자연스러운 표현
+    imageTag: 'v-building',
     branch,
     commitHash: targetCommitSha,
     project: { connect: { id: project.id } },


### PR DESCRIPTION
# PR

## PR 요약
프로젝트 상세 페이지 description 필드를 수정했습니다.

## 변경된 점
기존: description: \"${branch}" 브랜치 실행 (최소 기능) -> 개선: description: \${branch} 브랜치에서 배포된 버전입니다
기존: imageTag: 'pending-build' -> 개선: imageTag: 'v-building'

이미지 태그 변경은 실제 빌드와 무관합니다. pending-build는 임시 플레이스홀더일 뿐이라서, GitHub Actions가 실제 빌드 시 새 태그 생성 해줍니다.

## 이슈 번호
