### PR TITLE
feat:배포 결과 콜백 api & 승인 결정 api 분석 구현

### DIFF
--- a/src/pages/api/deployment/callback.ts
+++ b/src/pages/api/deployment/callback.ts
@@ -1,0 +1,52 @@
+// src/pages/api/deployment/callback.ts
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { updateVersionStatusSafely } from '@/services/version-service/version-status-updater.service';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+
+  const { versionId, status } = req.query;
+
+  if (!versionId || !status) {
+    return res.status(400).json({ message: 'Missing versionId or status' });
+  }
+
+  const versionIdNum = Number(versionId);
+  if (isNaN(versionIdNum)) {
+    return res.status(400).json({ message: 'Invalid versionId' });
+  }
+
+  if (!['success', 'fail'].includes(status as string)) {
+    return res.status(400).json({ message: 'Invalid status' });
+  }
+
+  try {
+    const deployStatus = status === 'success' ? 'success' : 'fail';
+    const flowStatus = status === 'success' ? 'success' : 'fail';
+
+    await updateVersionStatusSafely(versionIdNum, {
+      deployStatus,
+      flowStatus,
+    });
+
+    console.log(`[DEPLOYMENT CALLBACK] versionId=${versionId}, status=${status}`);
+
+    return res.status(200).json({ 
+      message: '배포 결과가 성공적으로 업데이트되었습니다',
+      versionId: versionIdNum,
+      status: deployStatus
+    });
+
+  } catch (error) {
+    console.error('[DEPLOYMENT CALLBACK ERROR]', error);
+    return res.status(500).json({
+      message: '배포 결과 업데이트 실패',
+      error: String(error),
+    });
+  }
+}

--- a/src/pages/api/versions/[versionId]/approval-decision.ts
+++ b/src/pages/api/versions/[versionId]/approval-decision.ts
@@ -1,0 +1,45 @@
+// src/pages/api/versions/[versionId]/approval-decision.ts
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { updateVersionStatusSafely } from '@/services/version-service/version-status-updater.service';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'PATCH') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+
+  const versionId = Number(req.query.versionId);
+  if (isNaN(versionId)) {
+    return res.status(400).json({ message: 'Invalid versionId' });
+  }
+
+  const { approved } = req.body;
+  if (typeof approved !== 'boolean') {
+    return res.status(400).json({ message: 'approved must be a boolean' });
+  }
+
+  try {
+    const approveStatus = approved ? 'approved' : 'rejected';
+    const flowStatus = approved ? 'pending' : 'fail'; // 승인되면 배포, 거부되면 실패
+
+    await updateVersionStatusSafely(versionId, {
+      approveStatus,
+      flowStatus,
+    });
+
+    return res.status(200).json({
+      message: `버전이 ${approved ? '승인' : '거부'}되었습니다`,
+      versionId,
+      status: approveStatus,
+    });
+
+  } catch (error) {
+    console.error('[APPROVAL DECISION ERROR]', error);
+    return res.status(500).json({
+      message: '승인 결정 처리 실패',
+      error: String(error),
+    });
+  }
+}


### PR DESCRIPTION
# PR

## PR 요약
사용자가 UI에서 배포 승인/거부 결정을 내릴 때 상태 업데이트하는 API 및 GitHub Actions 배포 워크플로우가 완료되면 플랫폼에 결과를 알려주는 웹훅 추가

## 변경된 점
None

## 이슈 번호
#158 